### PR TITLE
Add logs directory for conversation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+-e 
+# Conversation logs
+logs/conversations/*.json

--- a/cia.py
+++ b/cia.py
@@ -1,3 +1,4 @@
+LOGS_DIR = "logs/conversations"
 import os
 import signal
 import sys
@@ -236,7 +237,7 @@ Always provide the full command output to the user and explain its meaning.
 
     async def save_conversation(self):
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"conversation_{timestamp}.json"
+        filename = os.path.join(LOGS_DIR, f"conversation_\1.json")
         with open(filename, "w") as f:
             json.dump(self.messages, f)
         self.console.print(f"[bold green]Conversation saved as[/bold green] {filename}")


### PR DESCRIPTION
This PR makes minimal changes to organize conversation logs:

- Adds logs/conversations directory with .gitkeep
- Updates .gitignore to exclude JSON files in logs directory
- Updates cia.py to use LOGS_DIR constant for file paths

This keeps the repository root clean while maintaining a consistent location for conversation logs.